### PR TITLE
Potential fix for code scanning alert no. 5422: Cross-site scripting

### DIFF
--- a/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02721.java
+++ b/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02721.java
@@ -90,7 +90,7 @@ public class BenchmarkTest02721 extends HttpServlet {
                                         + " has been remembered with cookie: "
                                         + rememberMe.getName()
                                         + " whose value is: "
-                                        + rememberMe.getValue()
+                                        + org.springframework.web.util.HtmlUtils.htmlEscape(rememberMe.getValue())
                                         + "<br/>");
             }
         } catch (java.security.NoSuchAlgorithmException e) {


### PR DESCRIPTION
Potential fix for [https://github.com/octodemo/BenchmarkJavaOwaspA1DAM/security/code-scanning/5422](https://github.com/octodemo/BenchmarkJavaOwaspA1DAM/security/code-scanning/5422)

To fix the cross-site scripting vulnerability, we need to ensure that any data written to the response stream is properly sanitized or encoded. In this case, we should use HTML escaping to encode the value of `rememberMe.getValue()` before writing it to the response. This will prevent any malicious scripts from being executed in the user's browser.

We will use the `org.springframework.web.util.HtmlUtils.htmlEscape` method to escape the value of `rememberMe.getValue()` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
